### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url = env("DATABASE_URL") // uses connection pooling
-   directUrl = env("DATABASE_URL_NON_POOLING") // uses a direct connection
-  // shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
+  directUrl = env("DATABASE_URL_NON_POOLING") // used for migrations
 }
 
 model User {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.

It was commented out, but came up in an internal Prisma search. Better safe than sorry! 😅 